### PR TITLE
Kucoin.js createOrder Margin api fix

### DIFF
--- a/js/kucoin.js
+++ b/js/kucoin.js
@@ -1152,7 +1152,17 @@ module.exports = class kucoin extends Exchange {
             request['size'] = amountString;
             request['price'] = this.priceToPrecision (symbol, price);
         }
-        const response = await this.privatePostOrders (this.extend (request, params));
+
+        let method = 'privatePostOrders';
+
+        // We'll need to call the implicit `margin order` function instead of `orders` if tradeType is margin.
+        if (Object.prototype.hasOwnProperty.call(params, 'tradeType')) {
+          if (params.tradeType === 'MARGIN_TRADE') {
+            method = 'privatePostMarginOrder';
+          }
+        }
+
+        const response = await this[method] (this.extend (request, params));
         //
         //     {
         //         code: '200000',


### PR DESCRIPTION
Added a simple fix for the createOrder function of kucoin.js to support creating margin orders. Kucoin modified their api so that /orders will no longer support margin orders. /margin/order is now required.